### PR TITLE
Use vacuum entity battery level for sensor

### DIFF
--- a/custom_components/robovac/sensor.py
+++ b/custom_components/robovac/sensor.py
@@ -9,7 +9,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import CONF_VACS, DOMAIN, REFRESH_RATE
-from .vacuums.base import TuyaCodes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,11 +61,15 @@ class RobovacBatterySensor(SensorEntity):
         """Update the sensor state."""
         try:
             vacuum_entity = self.hass.data[DOMAIN][CONF_VACS].get(self.robovac_id)
-            if vacuum_entity and vacuum_entity.tuyastatus:
-                self._attr_native_value = vacuum_entity.tuyastatus.get(TuyaCodes.BATTERY_LEVEL)
+            battery_level = getattr(vacuum_entity, "battery_level", None)
+            if vacuum_entity and battery_level is not None:
+                self._attr_native_value = battery_level
                 self._attr_available = True
             else:
-                _LOGGER.debug("Vacuum entity or status not available for %s", self.robovac_id)
+                _LOGGER.debug(
+                    "Vacuum entity or battery level not available for %s",
+                    self.robovac_id,
+                )
                 self._attr_available = False
         except Exception as ex:
             _LOGGER.error("Failed to update battery sensor for %s: %s", self.robovac_id, ex)

--- a/tests/test_vacuum/test_sensor.py
+++ b/tests/test_vacuum/test_sensor.py
@@ -1,13 +1,12 @@
 """Tests for the RoboVac sensor component."""
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 from homeassistant.const import PERCENTAGE, CONF_ID
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 
 from custom_components.robovac.sensor import RobovacBatterySensor
-from custom_components.robovac.vacuums.base import TuyaCodes
 
 
 @pytest.mark.asyncio
@@ -39,7 +38,7 @@ async def test_battery_sensor_update_success():
 
     # Create mock vacuum entity
     mock_vacuum_entity = MagicMock()
-    mock_vacuum_entity.tuyastatus = {TuyaCodes.BATTERY_LEVEL: 85}
+    mock_vacuum_entity.battery_level = 85
 
     # Create mock hass data structure
     mock_hass = MagicMock()


### PR DESCRIPTION
## Summary
- use vacuum entity battery_level attribute instead of tuyastatus for battery sensor
- update battery sensor tests for new source

## Testing
- `pytest tests/test_vacuum/test_sensor.py`
- `pytest` *(fails: assertion errors in other tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b3aa151d34832e92ea3b4bb3aee1a2