### PR TITLE
Update battery sensor to refresh on setup

### DIFF
--- a/custom_components/robovac/sensor.py
+++ b/custom_components/robovac/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
         item = vacuums[item]
         entities.append(RobovacBatterySensor(item))
 
-    async_add_entities(entities)
+    async_add_entities(entities, True)
 
 
 class RobovacBatterySensor(SensorEntity):


### PR DESCRIPTION
## Summary
- populate battery sensor state immediately by refreshing once during setup
- test that setup triggers an initial battery update matching the vacuum entity

## Testing
- `pre-commit run --files custom_components/robovac/sensor.py tests/test_vacuum/test_sensor.py`
- `pytest tests/test_vacuum/test_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3b495d3c0832eb2c7fc257212ab9c