### PR TITLE
Handle unknown RoboVac X9 Pro statuses and expose charging

### DIFF
--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -50,6 +50,13 @@ class T2320(RobovacModelDetails):
         # Status reports via DP 153 (base64-encoded status payloads)
         RobovacCommand.STATUS: {
             "code": 153,
+            "values": {
+                # Observed when the vacuum is idle at the dock. Without this
+                # mapping Home Assistant would treat the state as cleaning.
+                # Mapping it to "standby" ensures the entity reports an idle
+                # activity instead.
+                "EhAFGgIIAToCEAJyBhoCCAEiAA==": "standby",
+            },
         },
         # Return home is triggered via MODE DP (152) on this model
         RobovacCommand.RETURN_HOME: {


### PR DESCRIPTION
## Summary
- map idle status for RoboVac X9 Pro so it no longer reports cleaning
- treat unmapped base64 states as idle and expose battery charging info

## Testing
- `pre-commit run --files custom_components/robovac/vacuum.py custom_components/robovac/vacuums/T2320.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d38cf41c832eac4a89388bed8b78