### PR TITLE
fix(t2320): map auto-return charging status

### DIFF
--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -56,6 +56,8 @@ class T2320(RobovacModelDetails):
                 # Mapping it to "standby" ensures the entity reports an idle
                 # activity instead.
                 "EhAFGgIIAToCEAJyBhoCCAEiAA==": "standby",
+                # Observed when the vacuum automatically returns to the dock to charge
+                "EAoAEAMaADICCAFaAHICIgA=": "Auto-return charging",
             },
         },
         # Return home is triggered via MODE DP (152) on this model


### PR DESCRIPTION
## Summary
- map T2320 status token `EAoAEAMaADICCAFaAHICIgA=` to `Auto-return charging`

## Testing
- `pre-commit run --files custom_components/robovac/vacuums/T2320.py`
- `pytest` *(fails: AssertionError: assert '153' == '173', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2312d7b0832e8484f1d725327e27