### PR TITLE
Map Drying Mop status for T2320 model

### DIFF
--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -1,5 +1,5 @@
 """Eufy Robot Vacuum and Mop X9 Pro with Auto-Clean Station (T2320)"""
-from homeassistant.components.vacuum import VacuumEntityFeature
+from homeassistant.components.vacuum import VacuumEntityFeature, VacuumActivity
 from .base import RoboVacEntityFeature, RobovacCommand, RobovacModelDetails
 
 
@@ -58,6 +58,8 @@ class T2320(RobovacModelDetails):
                 "EhAFGgIIAToCEAJyBhoCCAEiAA==": "standby",
                 # Observed when the vacuum automatically returns to the dock to charge
                 "EAoAEAMaADICCAFaAHICIgA=": "Auto-return charging",
+                # Observed when the mop is drying at the dock
+                "EBAFGgA6AhACcgYaAggBIgA=": "Drying Mop",
             },
         },
         # Return home is triggered via MODE DP (152) on this model
@@ -91,4 +93,10 @@ class T2320(RobovacModelDetails):
         RobovacCommand.ERROR: {
             "code": 0,
         },
+    }
+
+    activity_mapping = {
+        "Auto-return charging": VacuumActivity.DOCKED,
+        "Drying Mop": VacuumActivity.DOCKED,
+        "standby": VacuumActivity.IDLE,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ def mock_robovac():
     mock.async_set = AsyncMock(return_value=True)
     mock.async_disable = AsyncMock(return_value=True)
     mock.getRoboVacCommandValue.side_effect = _command_value
+    mock.getRoboVacActivityMapping.return_value = None
 
     return mock
 

--- a/tests/test_vacuum/test_dps_command_mapping.py
+++ b/tests/test_vacuum/test_dps_command_mapping.py
@@ -134,6 +134,22 @@ def test_getDpsCodes_extraction_method() -> None:
         assert t2320_dps_codes["ERROR_CODE"] != TuyaCodes.ERROR_CODE
 
 
+def test_status_mapping_t2320() -> None:
+    """Test T2320 status codes map to human-readable values."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        vacuum = RoboVac(
+            model_code="T2320",
+            device_id="test_id",
+            host="192.168.1.1",
+            local_key="test_key",
+        )
+
+        status = vacuum.getRoboVacHumanReadableValue(
+            RobovacCommand.STATUS, "EBAFGgA6AhACcgYaAggBIgA="
+        )
+        assert status == "Drying Mop"
+
+
 @pytest.mark.asyncio
 async def test_vacuum_update_uses_correct_dps_codes() -> None:
     """Test that vacuum update uses the right DPS codes for the model."""

--- a/tests/test_vacuum/test_vacuum_entity.py
+++ b/tests/test_vacuum/test_vacuum_entity.py
@@ -67,6 +67,22 @@ async def test_activity_property_docked(mock_robovac, mock_vacuum_data):
 
 
 @pytest.mark.asyncio
+async def test_activity_property_drying_mop(mock_robovac, mock_vacuum_data):
+    """Test activity property returns DOCKED when state is Drying Mop."""
+    mock_robovac.getRoboVacActivityMapping.return_value = {
+        "Drying Mop": VacuumActivity.DOCKED
+    }
+
+    with patch("custom_components.robovac.vacuum.RoboVac", return_value=mock_robovac):
+        entity = RoboVacEntity(mock_vacuum_data)
+        entity.tuya_state = "Drying Mop"
+
+        result = entity.activity
+
+        assert result == VacuumActivity.DOCKED
+
+
+@pytest.mark.asyncio
 async def test_activity_property_returning(mock_robovac, mock_vacuum_data):
     """Test activity property returns RETURNING when state is Recharge."""
     # Arrange


### PR DESCRIPTION
## Summary
- recognize "Drying Mop" status on T2320 vacuums
- map Drying Mop state to docked activity
- cover Drying Mop status in tests

## Testing
- `pre-commit run --files custom_components/robovac/vacuums/T2320.py tests/conftest.py tests/test_vacuum/test_vacuum_entity.py tests/test_vacuum/test_dps_command_mapping.py`
- `pytest tests/test_vacuum/test_vacuum_entity.py tests/test_vacuum/test_dps_command_mapping.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_68bb57c1c7d8832eaa36d637bb58edc0