### PR TITLE
Map fully charged status for T2320 vacuum

### DIFF
--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -56,6 +56,8 @@ class T2320(RobovacModelDetails):
                 # Mapping it to "standby" ensures the entity reports an idle
                 # activity instead.
                 "EhAFGgIIAToCEAJyBhoCCAEiAA==": "standby",
+                # Observed when the vacuum is fully charged and docked
+                "ChADGgIIAXICIgA=": "Fully Charged",
                 # Observed when the vacuum automatically returns to the dock to charge
                 "EAoAEAMaADICCAFaAHICIgA=": "Auto-return charging",
                 # Observed when the mop is drying at the dock
@@ -98,5 +100,6 @@ class T2320(RobovacModelDetails):
     activity_mapping = {
         "Auto-return charging": VacuumActivity.DOCKED,
         "Drying Mop": VacuumActivity.DOCKED,
+        "Fully Charged": VacuumActivity.DOCKED,
         "standby": VacuumActivity.IDLE,
     }

--- a/tests/test_vacuum/test_dps_command_mapping.py
+++ b/tests/test_vacuum/test_dps_command_mapping.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 from custom_components.robovac.robovac import RoboVac
 from custom_components.robovac.vacuum import RoboVacEntity
 from custom_components.robovac.vacuums.base import RobovacCommand, TuyaCodes
+from homeassistant.components.vacuum import VacuumActivity
 from homeassistant.const import (
     CONF_NAME,
     CONF_ID,
@@ -148,6 +149,25 @@ def test_status_mapping_t2320() -> None:
             RobovacCommand.STATUS, "EBAFGgA6AhACcgYaAggBIgA="
         )
         assert status == "Drying Mop"
+
+        status = vacuum.getRoboVacHumanReadableValue(
+            RobovacCommand.STATUS, "ChADGgIIAXICIgA="
+        )
+        assert status == "Fully Charged"
+
+
+def test_activity_mapping_fully_charged_t2320() -> None:
+    """Ensure Fully Charged status maps to DOCKED activity for T2320."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        vacuum = RoboVac(
+            model_code="T2320",
+            device_id="test_id",
+            host="192.168.1.1",
+            local_key="test_key",
+        )
+
+    mapping = vacuum.getRoboVacActivityMapping()
+    assert mapping.get("Fully Charged") == VacuumActivity.DOCKED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- map T2320 status `ChADGgIIAXICIgA=` to "Fully Charged" and treat as docked
- cover fully charged status in tests and verify activity mapping

## Testing
- `pre-commit run --files custom_components/robovac/vacuums/T2320.py tests/test_vacuum/test_dps_command_mapping.py`
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component', package requires Python 3.13)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e2ecfc4832e9419a666f7c1901f