### PR TITLE
Add auto cleaning status mapping for T2320

### DIFF
--- a/custom_components/robovac/vacuums/T2320.py
+++ b/custom_components/robovac/vacuums/T2320.py
@@ -62,6 +62,9 @@ class T2320(RobovacModelDetails):
                 "EAoAEAMaADICCAFaAHICIgA=": "Auto-return charging",
                 # Observed when the mop is drying at the dock
                 "EBAFGgA6AhACcgYaAggBIgA=": "Drying Mop",
+                # Observed when the vacuum is auto-cleaning off the dock
+                "CgoAEAUyAHICIgA=": "Auto Cleaning",
+                "DgoAEAUaAggBMgByAiIA": "Auto Cleaning",
             },
         },
         # Return home is triggered via MODE DP (152) on this model
@@ -101,5 +104,6 @@ class T2320(RobovacModelDetails):
         "Auto-return charging": VacuumActivity.DOCKED,
         "Drying Mop": VacuumActivity.DOCKED,
         "Fully Charged": VacuumActivity.DOCKED,
+        "Auto Cleaning": VacuumActivity.CLEANING,
         "standby": VacuumActivity.IDLE,
     }

--- a/tests/test_vacuum/test_dps_command_mapping.py
+++ b/tests/test_vacuum/test_dps_command_mapping.py
@@ -155,6 +155,11 @@ def test_status_mapping_t2320() -> None:
         )
         assert status == "Fully Charged"
 
+        status = vacuum.getRoboVacHumanReadableValue(
+            RobovacCommand.STATUS, "CgoAEAUyAHICIgA="
+        )
+        assert status == "Auto Cleaning"
+
 
 def test_activity_mapping_fully_charged_t2320() -> None:
     """Ensure Fully Charged status maps to DOCKED activity for T2320."""
@@ -168,6 +173,20 @@ def test_activity_mapping_fully_charged_t2320() -> None:
 
     mapping = vacuum.getRoboVacActivityMapping()
     assert mapping.get("Fully Charged") == VacuumActivity.DOCKED
+
+
+def test_activity_mapping_auto_cleaning_t2320() -> None:
+    """Ensure Auto Cleaning status maps to CLEANING activity for T2320."""
+    with patch("custom_components.robovac.robovac.TuyaDevice.__init__", return_value=None):
+        vacuum = RoboVac(
+            model_code="T2320",
+            device_id="test_id",
+            host="192.168.1.1",
+            local_key="test_key",
+        )
+
+    mapping = vacuum.getRoboVacActivityMapping()
+    assert mapping.get("Auto Cleaning") == VacuumActivity.CLEANING
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- map T2320 auto-cleaning status codes to human readable value and VacuumActivity
- test auto-cleaning status mapping and activity mapping

## Testing
- `pre-commit run --files custom_components/robovac/vacuums/T2320.py tests/test_vacuum/test_dps_command_mapping.py`
- `pytest tests/test_vacuum/test_dps_command_mapping.py::test_status_mapping_t2320 tests/test_vacuum/test_dps_command_mapping.py::test_activity_mapping_auto_cleaning_t2320`


------
https://chatgpt.com/codex/tasks/task_e_68c088f92a80832e929e8c664826fd1b